### PR TITLE
fix: enable go111 modules on makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ export m ?= default
 export commit ?= HEAD
 export bin ?= vitrine-social
 export testWatchPort=8091
+export GO111MODULE=on
 
 .PHONY: build
 


### PR DESCRIPTION
Como o readme instrui a clonar o repositório no `GOPATH`, precisamos setar `GO111MODULE` pra `on`, caso contrário o Go não usa os modules.