### PR TITLE
Issue 272 - Adição de campos ao form de edição do perfil da organização

### DIFF
--- a/frontend/src/components/OrganizationProfileForm/OrganizationProfileForm.js
+++ b/frontend/src/components/OrganizationProfileForm/OrganizationProfileForm.js
@@ -14,7 +14,7 @@ import cx from 'classnames';
 import ReactGA from 'react-ga';
 import UploadImages from '../UploadImages';
 import ResponseFeedback from '../ResponseFeedback';
-import { maskPhone, maskCep } from '../../utils/mask';
+import { maskPhone, maskCep, maskWhatsapp } from '../../utils/mask';
 import { api, apiImage } from '../../utils/api';
 import { getUser } from '../../utils/auth';
 import colors from '../../utils/styles/colors';
@@ -305,6 +305,15 @@ class OrganizationProfileForm extends React.Component {
               </Upload>
             </div>
             <Form>
+              <FormItem>
+                <Col
+                  md={{ span: 18, offset: 3 }}
+                  sm={{ span: 22, offset: 1 }}
+                  xs={{ span: 24, offset: 0 }}
+                >
+                  <h2 className={styles.galleryHeader}>Dados Básicos</h2>
+                </Col>
+              </FormItem>
               <FormItem {...formItemLayout}>
                 {getFieldDecorator('name', {
                   rules: [{ required: true, message: 'Preencha o nome da organização' }],
@@ -326,13 +335,6 @@ class OrganizationProfileForm extends React.Component {
                 )}
               </FormItem>
               <FormItem {...formItemLayout}>
-                {getFieldDecorator('website', {
-                  initialValue: organization.website,
-                })(
-                  <Input size="large" placeholder="Website" />,
-                )}
-              </FormItem>
-              <FormItem {...formItemLayout}>
                 {getFieldDecorator('phone', {
                   getValueFromEvent: e => maskPhone(e.target.value),
                   rules: [{
@@ -345,26 +347,57 @@ class OrganizationProfileForm extends React.Component {
                   <Input size="large" placeholder="Telefone" />,
                 )}
               </FormItem>
+              <FormItem>
+                <Col
+                  md={{ span: 18, offset: 3 }}
+                  sm={{ span: 22, offset: 1 }}
+                  xs={{ span: 24, offset: 0 }}
+                >
+                  <h2 className={styles.galleryHeader}>Links / Redes Sociais</h2>
+                </Col>
+              </FormItem>
               <FormItem {...formItemLayout}>
-                {getFieldDecorator('whatsapp', {
-                  initialValue: organization.whatsapp,
+                {getFieldDecorator('website', {
+                  initialValue: organization.website,
                 })(
-                  <Input size="large" placeholder="Whatsapp" />,
+                  <Input size="large" placeholder="Website" />,
                 )}
               </FormItem>
               <FormItem {...formItemLayout}>
                 {getFieldDecorator('facebook', {
                   initialValue: organization.facebook,
                 })(
-                  <Input size="large" placeholder="Facebook" />,
+                  <Input addonBefore="https://www.facebook.com/" size="large" placeholder="" />,
                 )}
               </FormItem>
               <FormItem {...formItemLayout}>
                 {getFieldDecorator('instagram', {
                   initialValue: organization.instagram,
                 })(
-                  <Input size="large" placeholder="Instagram" />,
+                  <Input addonBefore="https://www.instagram.com/" size="large" placeholder="" />,
                 )}
+              </FormItem>
+              <FormItem {...formItemLayout}>
+                {getFieldDecorator('whatsapp', {
+                  getValueFromEvent: e => maskWhatsapp(e.target.value),
+                  rules: [{
+                    pattern: /^(\(0?([1-9a-zA-Z][0-9a-zA-Z])?[1-9]\d\) ?|0?([1-9a-zA-Z][0-9a-zA-Z])?[1-9]\d[ .-]?)?(9|9[ .-])?[2-9]\d{3}[ .-]?\d{4}$/gm, message: 'Whatsapp Inválido',
+                  }],
+                  initialValue: organization.whatsapp ?
+                    maskWhatsapp(organization.whatsapp) :
+                    null,
+                })(
+                  <Input size="large" placeholder="Whatsapp" />,
+                )}
+              </FormItem>
+              <FormItem>
+                <Col
+                  md={{ span: 18, offset: 3 }}
+                  sm={{ span: 22, offset: 1 }}
+                  xs={{ span: 24, offset: 0 }}
+                >
+                  <h2 className={styles.galleryHeader}>Endereço</h2>
+                </Col>
               </FormItem>
               <FormItem
                 {...formItemLayout}

--- a/frontend/src/components/OrganizationProfileForm/OrganizationProfileForm.js
+++ b/frontend/src/components/OrganizationProfileForm/OrganizationProfileForm.js
@@ -167,6 +167,9 @@ class OrganizationProfileForm extends React.Component {
           email: values.email,
           website: values.website,
           phone: values.phone,
+          whatsapp: values.whatsapp,
+          facebook: values.facebook,
+          instagram: values.instagram,
           address,
           about: values.about,
         };
@@ -340,6 +343,27 @@ class OrganizationProfileForm extends React.Component {
                   initialValue: maskPhone(organization.phone),
                 })(
                   <Input size="large" placeholder="Telefone" />,
+                )}
+              </FormItem>
+              <FormItem {...formItemLayout}>
+                {getFieldDecorator('whatsapp', {
+                  initialValue: organization.whatsapp,
+                })(
+                  <Input size="large" placeholder="Whatsapp" />,
+                )}
+              </FormItem>
+              <FormItem {...formItemLayout}>
+                {getFieldDecorator('facebook', {
+                  initialValue: organization.facebook,
+                })(
+                  <Input size="large" placeholder="Facebook" />,
+                )}
+              </FormItem>
+              <FormItem {...formItemLayout}>
+                {getFieldDecorator('instagram', {
+                  initialValue: organization.instagram,
+                })(
+                  <Input size="large" placeholder="Instagram" />,
                 )}
               </FormItem>
               <FormItem

--- a/frontend/src/utils/mask.js
+++ b/frontend/src/utils/mask.js
@@ -57,4 +57,14 @@ const maskCep = cep => (
   cep.replace(/(\d{5})(\d)/, '$1-$2')
 );
 
-export { maskPhone, maskCpf, maskCnpj, maskCpfCnpj, maskCep };
+const maskWhatsapp = whatsapp => (
+  whatsapp.replace(/\D/g, '')
+    .replace(/^(\d)/, '($1')
+    .replace(/^(\(\d{2})(\d)/, '$1) $2')
+    .replace(/(\d{4})(\d{1,4})/, '$1-$2')
+    .replace(/(\d{5})(\d{5})/, '$1-$2')
+    .replace(/(-\d{5})\d+?$/, '$1')
+    .replace(/(\d{4})-(\d{1})(\d{4})/, '$1$2-$3')
+);
+
+export { maskPhone, maskCpf, maskCnpj, maskCpfCnpj, maskCep, maskWhatsapp };

--- a/frontend/src/utils/styles/global.module.scss
+++ b/frontend/src/utils/styles/global.module.scss
@@ -159,6 +159,14 @@ require('./colors.js');
     }
   }
 
+  .ant-input-group-addon {
+    color: $purple_400;
+    border: 2px solid $purple_400;
+    border-radius: 20px;
+    background-color: $grey_090;
+    font-size: 13px;
+  }
+
   .ant-input-number-input {
     border: none;
     background-color: transparent;


### PR DESCRIPTION
# This PR is connected to a issue?

connected to #272 

## This PR needs some special attention?

Com a adição dos addons aos inputs de facebook e instagram, poderá ser necessário uma alteração ao tratamento dos campos.
Seria necessário alterar o que esses campos representam, no caso o campo de facebook/instagram representaria apenas o alias do usuário ao invés do link completo. Ou então fazer um tratamento do valor do input para remover/incluir a primeira parte da url

## Resultado atual da tela

![screen shot 2018-10-18 at 23 57 41](https://user-images.githubusercontent.com/13739505/47195878-4558ae80-d334-11e8-8bba-fa60c5ddb441.png)