### PR TITLE
desativar metabase

### DIFF
--- a/devops/Caddyfile
+++ b/devops/Caddyfile
@@ -2,8 +2,3 @@ api.vitrinesocial.org {
   # API load balancer
   proxy /v1 localhost:8000
 }
-
-metabase.vitrinesocial.org {
-  # API load balancer
-  proxy / localhost:3000
-}

--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -1,17 +1,16 @@
 #!/bin/sh
 
 # Stop server service
-ssh -i ./devops/vitrinesocial.pem -t $DEPLOY_USER@$DEPLOY_HOST 'sudo systemctl stop caddy vitrine-social && docker-compose down'
+ssh -i ./devops/vitrinesocial.pem -t $DEPLOY_USER@$DEPLOY_HOST 'sudo systemctl stop caddy vitrine-social'
 
 # Upload new Caddy config file and docker-compose
 scp -i ./devops/vitrinesocial.pem devops/Caddyfile $DEPLOY_USER@$DEPLOY_HOST:~/
-scp -i ./devops/vitrinesocial.pem devops/docker-compose.yml $DEPLOY_USER@$DEPLOY_HOST:~/
 
 # Upload new compiled file
 scp -i ./devops/vitrinesocial.pem server/vitrine-social $DEPLOY_USER@$DEPLOY_HOST:~/vitrine-social/
 
 # Start serve service
-ssh -i ./devops/vitrinesocial.pem -t $DEPLOY_USER@$DEPLOY_HOST 'sudo systemctl start caddy vitrine-social && docker-compose up -d'
+ssh -i ./devops/vitrinesocial.pem -t $DEPLOY_USER@$DEPLOY_HOST 'sudo systemctl start caddy vitrine-social'
 
 # Run Migrations
 sql-migrate up -config=devops/dbconfig.yml -env=production


### PR DESCRIPTION
estou "desativando" o metabase do servidor do vitrine social, sempre que ele esta rodando o servidor parece ficar sem memória, o `sitemap-generate` não consegue rodar por falta de recursos.

Como ele parece não estar sendo utilizado, vou tirar ele, e no futuro podemos colocá-lo em um novo servidor, separado da aplicação para evitar esse tipo de problema.