### PR TITLE
Add go get sql-migrate to make install for deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ update-dev-dependences: # update dev dependences to the most recent
 install: ## install project dependences
 	go get github.com/haya14busa/goverage
 	go get golang.org/x/lint/golint
+	go get github.com/rubenv/sql-migrate
 	cd server; go mod tidy ; go mod download
 
 install-frontend: ## install frontend dependences


### PR DESCRIPTION
Travis não está encontrando o pacote `sql-migrate` no deploy.
Adicionei no install que é chamado antes.

```
./devops/deploy.sh: 16: ./devops/deploy.sh: sql-migrate: not found
2018/11/12 11:04:46 Error loading file config/.env
2018/11/12 11:04:46 /home/travis/gopath/src/github.com/Coderockr/vitrine-social/server/cmd/sitemap.go:50: stow: unknown kind
Connection to [secure] closed.
Script failed with status 1
failed to deploy
```